### PR TITLE
Remove support for py 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers=[
     "Topic :: Office/Business",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,pypy3
+envlist = py38,py39,py310,pypy3
 isolated_build = true
 
 [gh-actions]
@@ -7,7 +7,6 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311
     pypy-3.9: pypy3
 
 [testenv]


### PR DESCRIPTION
There is a issue with lxml and python 3.11 on windows.

See: https://github.com/acheong08/ChatGPT/issues/53